### PR TITLE
Iimprove wkview shared code

### DIFF
--- a/WinkKit.xcodeproj/project.pbxproj
+++ b/WinkKit.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		1F34ADD622636F6100371DEC /* WKMiscCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F34ADD522636F6100371DEC /* WKMiscCode.swift */; };
 		1F34ADD92263718A00371DEC /* WKApiSimpleError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F34ADD82263718A00371DEC /* WKApiSimpleError.swift */; };
 		1F34ADDB226371B300371DEC /* WKApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F34ADDA226371B300371DEC /* WKApiError.swift */; };
+		1F431BE6228845FB008D802C /* WKViewLifecycleImplementations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F431BE5228845FB008D802C /* WKViewLifecycleImplementations.swift */; };
 		1F8FB7F02194A6C100C8F556 /* IBDesignableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FB7EF2194A6C100C8F556 /* IBDesignableTests.swift */; };
 		1F8FB7FF2195D1B100C8F556 /* TestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FB7FD2195D1B100C8F556 /* TestViewController.swift */; };
 		1F8FB8002195D1B100C8F556 /* TestPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8FB7FE2195D1B100C8F556 /* TestPresenter.swift */; };
@@ -143,6 +144,7 @@
 		1F34ADD522636F6100371DEC /* WKMiscCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKMiscCode.swift; sourceTree = "<group>"; };
 		1F34ADD82263718A00371DEC /* WKApiSimpleError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKApiSimpleError.swift; sourceTree = "<group>"; };
 		1F34ADDA226371B300371DEC /* WKApiError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKApiError.swift; sourceTree = "<group>"; };
+		1F431BE5228845FB008D802C /* WKViewLifecycleImplementations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WKViewLifecycleImplementations.swift; sourceTree = "<group>"; };
 		1F8FB7ED2194A6C100C8F556 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1F8FB7EF2194A6C100C8F556 /* IBDesignableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IBDesignableTests.swift; sourceTree = "<group>"; };
 		1F8FB7F12194A6C100C8F556 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -306,6 +308,7 @@
 				1F34AD9522636D5F00371DEC /* Table View */,
 				1F34AD9A22636D5F00371DEC /* WKView.swift */,
 				1F34AD9B22636D5F00371DEC /* Collection View */,
+				1F431BE5228845FB008D802C /* WKViewLifecycleImplementations.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -678,6 +681,7 @@
 				1F34ADBF22636D5F00371DEC /* WKButton.swift in Sources */,
 				1F34ADD422636F0C00371DEC /* WKCode.swift in Sources */,
 				1F34ADB422636D5F00371DEC /* WKViewControllerPresenter.swift in Sources */,
+				1F431BE6228845FB008D802C /* WKViewLifecycleImplementations.swift in Sources */,
 				1F34ADCF22636E6D00371DEC /* WKFullResult.swift in Sources */,
 				1F34ADC122636D5F00371DEC /* WKTableView.swift in Sources */,
 				1F34ADC422636D5F00371DEC /* WKTableViewInfiniteDataSourceDelegate.swift in Sources */,

--- a/WinkKit/Public/Presentation/Views/WKButton.swift
+++ b/WinkKit/Public/Presentation/Views/WKButton.swift
@@ -14,28 +14,29 @@ import UIKit
 ///
 open class WKButton: UIButton {
     
-    // MARK: Initializers
+    // MARK: - Initializers
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
     
+    // MARK: - deinit
+    
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKImageView.swift
+++ b/WinkKit/Public/Presentation/Views/WKImageView.swift
@@ -10,17 +10,17 @@ import UIKit
 
 @IBDesignable
 open class WKImageView: UIImageView {
-
-    // MARK: Initializers
+    
+    // MARK: - Initializers
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
     public override init(image: UIImage?) {
@@ -32,16 +32,13 @@ open class WKImageView: UIImageView {
         super.init(image: image, highlightedImage: highlightedImage)
         addCornerRadiusObserver()
     }
-
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
-    
     
     // MARK: Overriden `WKPropertiesInspectable` methods
     
@@ -58,27 +55,18 @@ open class WKImageView: UIImageView {
     // MARK: - Private Methods
     
     private func roundImage() {
-        if let image = self.image {
-            
-            // Begin a new image that will be the new image with the rounded corners
-            // (here with the size of an UIImageView)
-            UIGraphicsBeginImageContextWithOptions(bounds.size, false, UIScreen.main.scale)
-            
-            // Add a clip before drawing anything, in the shape of an rounded rect
-            UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).addClip()
-            
-            image.draw(in: bounds)
-            
-            // Get the image, here setting the UIImageView image
-            self.image = UIGraphicsGetImageFromCurrentImageContext()
-            
-            // Lets forget about that we were drawing
-            UIGraphicsEndImageContext()
-        }
+        guard let image = image else { return }
+        UIGraphicsBeginImageContextWithOptions(bounds.size, false, UIScreen.main.scale)
+        UIBezierPath(roundedRect: bounds, cornerRadius: cornerRadius).addClip()
+        image.draw(in: bounds)
+        self.image = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
     }
+
+    // MARK: - deinit
     
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKLabel.swift
+++ b/WinkKit/Public/Presentation/Views/WKLabel.swift
@@ -14,28 +14,29 @@ import Foundation
 ///
 open class WKLabel: UILabel {
     
-    // MARK: Initializers
+    // MARK: - Initializers
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
     
+    // MARK: - deinit
+    
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKTextField.swift
+++ b/WinkKit/Public/Presentation/Views/WKTextField.swift
@@ -14,28 +14,29 @@ import Foundation
 ///
 open class WKTextField: UITextField {
     
-    // MARK: Initializers
+    // MARK: - Initializers
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
     
+    // MARK: - deinit
+    
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKTextView.swift
+++ b/WinkKit/Public/Presentation/Views/WKTextView.swift
@@ -14,28 +14,29 @@ import Foundation
 ///
 open class WKTextView: UITextView {
     
-    // MARK: Initializers
+    // MARK: - Initializers
     
     public override init(frame: CGRect, textContainer: NSTextContainer?) {
         super.init(frame: frame, textContainer: textContainer)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
     
+    // MARK: - deinit
+    
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKView.swift
+++ b/WinkKit/Public/Presentation/Views/WKView.swift
@@ -445,29 +445,29 @@ extension UIView: WKPropertiesInspectable {
 /// wrap a `UIView` in this `WKView`.
 open class WKView: UIView {
     
-    // MARK: Initializers
+    // MARK: - Initializers
     
     public override init(frame: CGRect) {
         super.init(frame: frame)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithFrame(in: self)
     }
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        addCornerRadiusObserver()
+        WKViewLifecycleImplementations.initWithCoder(in: self)
     }
     
-    // MARK: UIView Lifecycle
+    // MARK: - Lifecycle
     
     open override func layoutSubviews() {
         super.layoutSubviews()
-        roundLayerIfNeeded()
-        updateShadowIfNeeded()
-        gradientLayer?.frame = bounds
+        WKViewLifecycleImplementations.layoutSubviews(in: self)
     }
     
+    // MARK: - deinit
+    
     deinit {
-        removeCornerRadiusObserver()
+        WKViewLifecycleImplementations.deinitIn(view: self)
     }
     
 }

--- a/WinkKit/Public/Presentation/Views/WKViewLifecycleImplementations.swift
+++ b/WinkKit/Public/Presentation/Views/WKViewLifecycleImplementations.swift
@@ -1,0 +1,37 @@
+//
+//  WKViewLifecycleImplementations.swift
+//  WinkKit
+//
+//  Created by Rico Crescenzio on 12/05/2019.
+//  Copyright © 2019 Wink srl. All rights reserved.
+//
+
+import Foundation
+
+struct WKViewLifecycleImplementations {
+    
+    // MARK: - UIView init
+    
+    static func initWithFrame(in view: UIView) {
+        view.addCornerRadiusObserver()
+    }
+    
+    static func initWithCoder(in view: UIView) {
+        view.addCornerRadiusObserver()
+    }
+    
+    // MARK: - UIView Lifecycle
+    
+    static func layoutSubviews(in view: UIView) {
+        view.roundLayerIfNeeded()
+        view.updateShadowIfNeeded()
+        view.gradientLayer?.frame = view.bounds
+    }
+    
+    // MARK: - UIView deinit
+
+    static func deinitIn(view: UIView) {
+        view.removeCornerRadiusObserver()
+    }
+    
+}


### PR DESCRIPTION
Problem
---

Right now for every `WKView` we need to write every time the same code for initializers and layout subviews implementation. We should avoid this code duplication.

Proposed solution
---

Create a kind of proxy that is called in every view class and actually do the work. For example:
```swift
func layoutSubviews(in view: UIView) {
    view.roundCornerIfNeeded()
    ...
}

class WKView: UIView {
    
    override func layoutSubviews() {
        super.layoutSubviews()
        layoutSubviews(in: self)        
    }

}

class WKLabel: UILabel {
    
    override func layoutSubviews() {
        super.layoutSubviews()
        layoutSubviews(in: self)        
    }

}
```
